### PR TITLE
增加 ghcr.io 容器构建

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,7 @@ name: Java CI with Maven
 # The API requires write permission on the repository to submit dependencies
 permissions:
   contents: write
+  packages: write
 
 on:
   push:
@@ -25,12 +26,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'yarn'
+        cache-dependency-path: 'web-front/yarn.lock'
+
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+
+    - name: Build Frontend
+      run: cd web-front && yarn install && yarn run build
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
@@ -43,3 +55,26 @@ jobs:
 #    - uses: release-drafter/release-drafter@v5
 #      env:
 #        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: web-service/target/netdisk-fast-download-bin.zip
+
+    - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      if: github.event_name != 'pull_request'
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+          ghcr.io/${{ github.repository }}:main

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,6 +49,7 @@ jobs:
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@v3
+      if: github.event_name != 'pull_request'
       with:
         ignore-maven-wrapper: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:17-alpine
+
+WORKDIR /app
+
+COPY ./web-service/target/netdisk-fast-download-bin.zip .
+
+RUN unzip netdisk-fast-download-bin.zip && \
+    mv netdisk-fast-download/* ./ && \
+    rm netdisk-fast-download-bin.zip && \
+    chmod +x run.sh
+
+EXPOSE 6400 6401
+
+ENTRYPOINT ["sh", "run.sh"]

--- a/README.md
+++ b/README.md
@@ -153,6 +153,31 @@ mvn package
 ```
 打包好的文件位于 web-service/target/netdisk-fast-download-bin.zip
 ## Linux服务部署
+
+### Docker 部署（Main分支）
+
+```shell
+# 创建目录
+mkdir -p netdisk-fast-download
+cd netdisk-fast-download
+
+# 拉取镜像
+docker pull ghcr.io/qaiu/netdisk-fast-download:main
+
+# 复制配置文件（或下载仓库web-service\src\main\resources）
+docker create --name netdisk-fast-download ghcr.io/qaiu/netdisk-fast-download:main
+docker cp netdisk-fast-download:/app/resources ./resources
+docker rm netdisk-fast-download
+
+# 启动容器
+docker run -d -it --name netdisk-fast-download -p 6401:6401 --restart unless-stopped -e TZ=Asia/Shanghai -v ./resources:/app/resources -v ./db:/app/db -v ./logs:/app/logs ghcr.io/qaiu/netdisk-fast-download:main
+
+# 反代6401端口
+
+# 升级容器
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --cleanup --run-once netdisk-fast-download
+```
+
 ### [宝塔安装参考](https://blog.qaiu.top/archives/netdisk-fast-download-bao-ta-an-zhuang-jiao-cheng)
 > 注意: netdisk-fast-download.service中的ExecStart的路径改为实际路径
 ```shell


### PR DESCRIPTION
由于不方便在服务器上安装 java ，增加构建容器镜像并发布到 ghcr.io 以通过 Docker 进行部署

不太熟悉这个项目，如有不合适的地方请修改
