### PR TITLE
fix: UC subdirectory listing fails due to missing stoken parameter

### DIFF
--- a/web-service/doc/openapi.json
+++ b/web-service/doc/openapi.json
@@ -386,6 +386,16 @@
               "type": "string",
               "example": "uuid123"
             }
+          },
+          {
+            "name": "stoken",
+            "in": "query",
+            "required": false,
+            "description": "分享 token，用于子目录解析时复用认证状态",
+            "schema": {
+              "type": "string",
+              "example": "OASBe5qM0pg2VvvyLM..."
+            }
           }
         ],
         "responses": {

--- a/web-service/src/main/java/cn/qaiu/lz/common/util/URLParamUtil.java
+++ b/web-service/src/main/java/cn/qaiu/lz/common/util/URLParamUtil.java
@@ -70,7 +70,7 @@ public class URLParamUtil {
         for (String paramName : params.names()) {
             // 忽略 "url", "pwd", "dirId", "uuid", "auth" 参数（这些参数单独处理，不应拼接到分享URL中）
             if (!paramName.equals("url") && !paramName.equals("pwd") && !paramName.equals("dirId") 
-                    && !paramName.equals("uuid") && !paramName.equals("auth")) {
+                    && !paramName.equals("uuid") && !paramName.equals("auth") && !paramName.equals("stoken")) {
                 if (firstParam) {
                     urlBuilder.append("?");
                     firstParam = false;

--- a/web-service/src/main/java/cn/qaiu/lz/common/util/URLParamUtil.java
+++ b/web-service/src/main/java/cn/qaiu/lz/common/util/URLParamUtil.java
@@ -68,7 +68,7 @@ public class URLParamUtil {
         boolean firstParam = !decodedUrl.contains("?");
 
         for (String paramName : params.names()) {
-            // 忽略 "url", "pwd", "dirId", "uuid", "auth" 参数（这些参数单独处理，不应拼接到分享URL中）
+            // 忽略 "url", "pwd", "dirId", "uuid", "auth", "stoken" 参数（这些参数单独处理，不应拼接到分享URL中）
             if (!paramName.equals("url") && !paramName.equals("pwd") && !paramName.equals("dirId") 
                     && !paramName.equals("uuid") && !paramName.equals("auth") && !paramName.equals("stoken")) {
                 if (firstParam) {

--- a/web-service/src/main/java/cn/qaiu/lz/web/controller/ParserApi.java
+++ b/web-service/src/main/java/cn/qaiu/lz/web/controller/ParserApi.java
@@ -161,7 +161,7 @@ public class ParserApi {
 
     @RouteMapping("/getFileList")
     public Future<List<FileInfo>> getFileList(HttpServerRequest request, String pwd, String dirId, String uuid,
-                                             String auth) {
+                                             String stoken, String auth) {
         String url = URLParamUtil.parserParams(request);
         ParserCreate parserCreate;
         try {
@@ -175,6 +175,9 @@ public class ParserApi {
         parserCreate.getShareLinkInfo().getOtherParam().put("_requestOrigin", linkPrefix);
         if (StringUtils.isNotBlank(dirId)) {
             parserCreate.getShareLinkInfo().getOtherParam().put("dirId", dirId);
+        }
+        if (StringUtils.isNotBlank(stoken)) {
+            parserCreate.getShareLinkInfo().getOtherParam().put("stoken", stoken);
         }
         if (StringUtils.isNotBlank(uuid)) {
             parserCreate.getShareLinkInfo().getOtherParam().put("uuid", uuid);


### PR DESCRIPTION
When browsing UC drive shares with directory structure, clicking into a
subdirectory returns HTTP 500: "Not implemented yet".

## Root cause

Two issues cause the stoken query parameter to be dropped:

1. **URLParamUtil.handleTruncatedUrl()** — the exclusion list that prevents
   special params from being appended to the share URL does not include
   `stoken`. This causes `?stoken=xxx` to be concatenated onto the UC share
   URL, breaking the `PanDomainTemplate` regex match and falling back to
   the default `IPanTool.parseFileList()`.

2. **ParserApi.getFileList()** — the method signature and `otherParam`
   forwarding both omit `stoken`. `UcTool.parseFileList()` relies on
   `otherParam.get("stoken")` to skip re-authentication; without it, the
   parser must call the UC API again, which fails without auth cookies.

## Fix

- `URLParamUtil.java`: add `stoken` to the param exclusion list (+1 line)
- `ParserApi.java`: add `String stoken` parameter and forward to `otherParam`
  (+4 lines)

## Verification

| Scenario | Before | After |
|---|---|---|
| Root directory listing | ✅ 200 | ✅ 200 |
| Subdirectory listing (with stoken) | ❌ 500 "Not implemented yet" | ✅ 200 |
| Nested subdirectory listing | ❌ 500 | ✅ 200 |