### PR TITLE
fix(security): GHSA-997r SSRF verification + residual hardening

### DIFF
--- a/parser/src/main/java/cn/qaiu/parser/PanBase.java
+++ b/parser/src/main/java/cn/qaiu/parser/PanBase.java
@@ -382,9 +382,10 @@ public abstract class PanBase implements IPanTool, Closeable {
                 log.error("响应gzip解压或JSON解析失败: {}", e.getMessage());
                 fail("响应gzip解压或JSON解析失败: {}", e.getMessage());
             } else {
+                // 上游响应体可能来自内网探测目标，仅写日志，避免经 HTTP 500 回传给调用方
                 String bodyPreview = responseBodyPreview(res);
                 log.error("解析失败: json格式异常: {}", bodyPreview);
-                fail("解析失败: json格式异常: {}", bodyPreview);
+                fail("解析失败: json格式异常");
             }
             return JsonObject.of();
         }

--- a/parser/src/main/java/cn/qaiu/parser/impl/Ce4Tool.java
+++ b/parser/src/main/java/cn/qaiu/parser/impl/Ce4Tool.java
@@ -111,7 +111,8 @@ public class Ce4Tool extends PanBase {
     private void requestShareDetail(String baseUrl, String key, String pwd, String path) {
         String shareApiUrl = baseUrl + SHARE_API_PATH + key;
         
-        HttpRequest<Buffer> httpRequest = clientSession.getAbs(shareApiUrl);
+        // 禁止跟随重定向：防止公网 host 302 到内网/元数据绕过 assertPublicHost
+        HttpRequest<Buffer> httpRequest = clientNoRedirects.getAbs(shareApiUrl);
         if (pwd != null && !pwd.isEmpty()) {
             httpRequest.addQueryParam("password", pwd);
         }
@@ -232,7 +233,7 @@ public class Ce4Tool extends PanBase {
                 .put("uris", new JsonArray().add(filePath))
                 .put("download", true);
         
-        clientSession.postAbs(fileUrlApi)
+        clientNoRedirects.postAbs(fileUrlApi)
                 .putHeader("Content-Type", "application/json")
                 .sendJsonObject(requestBody)
                 .onSuccess(res -> {

--- a/parser/src/main/java/cn/qaiu/parser/impl/CeTool.java
+++ b/parser/src/main/java/cn/qaiu/parser/impl/CeTool.java
@@ -78,7 +78,8 @@ public class CeTool extends PanBase {
     private void tryV4Ping(String baseUrl, String key, String pwd) {
         String pingUrlV4 = baseUrl + PING_API_V4_PATH;
         
-        clientSession.getAbs(pingUrlV4).send().onSuccess(res -> {
+        // 禁止跟随重定向：assertPublicHost 只校验初始 host，自动 30x 会绕过 SSRF 防护
+        clientNoRedirects.getAbs(pingUrlV4).send().onSuccess(res -> {
             if (res.statusCode() == 200) {
                 try {
                     JsonObject json = asJson(res);
@@ -108,7 +109,7 @@ public class CeTool extends PanBase {
     private void tryV3Ping(String baseUrl, String key, String pwd) {
         String pingUrlV3 = baseUrl + PING_API_V3_PATH;
         
-        clientSession.getAbs(pingUrlV3).send().onSuccess(res -> {
+        clientNoRedirects.getAbs(pingUrlV3).send().onSuccess(res -> {
             if (res.statusCode() == 200) {
                 try {
                     JsonObject json = asJson(res);
@@ -139,7 +140,7 @@ public class CeTool extends PanBase {
      */
     private void verifyV3AndParse(String baseUrl, String key, String pwd) {
         String shareApiUrl = baseUrl + SHARE_API_PATH + key;
-        HttpRequest<Buffer> httpRequest = clientSession.getAbs(shareApiUrl);
+        HttpRequest<Buffer> httpRequest = clientNoRedirects.getAbs(shareApiUrl);
         if (pwd != null && !pwd.isEmpty()) {
             httpRequest.addQueryParam("password", pwd);
         }
@@ -175,7 +176,7 @@ public class CeTool extends PanBase {
      */
     private void tryV4ShareApi(String baseUrl, String key, String pwd) {
         String shareApiUrl = baseUrl + "/api/v4/share/info/" + key;
-        HttpRequest<Buffer> httpRequest = clientSession.getAbs(shareApiUrl);
+        HttpRequest<Buffer> httpRequest = clientNoRedirects.getAbs(shareApiUrl);
         if (pwd != null && !pwd.isEmpty()) {
             httpRequest.addQueryParam("password", pwd);
         }
@@ -291,7 +292,8 @@ public class CeTool extends PanBase {
     }
 
     private void getDownURL(String shareApiUrl) {
-        clientSession.putAbs(shareApiUrl)
+        // PUT 默认不跟随重定向，但仍统一使用 no-redirect 客户端避免配置漂移
+        clientNoRedirects.putAbs(shareApiUrl)
                 .putHeader("Referer", shareLinkInfo.getShareUrl())
                 .send().onSuccess(res -> {
             JsonObject jsonObject = asJson(res);

--- a/parser/src/test/java/cn/qaiu/parser/AssertPublicHostTest.java
+++ b/parser/src/test/java/cn/qaiu/parser/AssertPublicHostTest.java
@@ -1,0 +1,44 @@
+package cn.qaiu.parser;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * GHSA-997r-7xx2-p9x6 regression: Cloudreve generic parser must reject
+ * hosts that resolve to loopback / private / link-local / metadata ranges
+ * before any outbound request.
+ */
+public class AssertPublicHostTest {
+
+    @Test
+    public void rejectsLoopbackAndPrivateHosts() throws Exception {
+        String[] blocked = {
+                "http://127.0.0.1.nip.io/s/poc",
+                "http://localhost/s/poc",
+                "http://10.0.0.1/s/poc",
+                "http://192.168.1.1/s/poc",
+                "http://172.16.0.1/s/poc",
+                "http://169.254.169.254/s/poc",
+                "http://[::1]/s/poc"
+        };
+        for (String raw : blocked) {
+            try {
+                PanBase.assertPublicHost(new URL(raw));
+                fail("expected block for " + raw);
+            } catch (IOException expected) {
+                assertTrue(expected.getMessage().contains("不允许访问")
+                        || expected.getMessage().contains("无法解析"));
+            }
+        }
+    }
+
+    @Test
+    public void allowsPublicHost() throws Exception {
+        PanBase.assertPublicHost(new URL("https://example.com/s/demo"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Verification of [GHSA-997r-7xx2-p9x6](https://github.com/qaiu/netdisk-fast-download/security/advisories/GHSA-997r-7xx2-p9x6) (Cloudreve generic parser SSRF) and follow-up hardening for residual bypasses left after `aeb4394`.

## Verification results (contributor feedback)

### Advisory PoC — confirmed on vulnerable `v0.4.1` / `b70e307`
```http
GET /json/parser?url=http://127.0.0.1.nip.io:18080/s/poc
```
Returned HTTP 500 with leaked loopback marker:
`解析失败: json格式异常: INTERNAL-SSRF-PROOF`

**Attack complexity for the reported issue: AC:L (Low)** — matches the advisory CVSS vector. No auth, no user interaction; attacker only needs a DNS name (or `nip.io`) resolving to an internal address.

### Same PoC — blocked on `aeb4394` / `v0.4.2`
```
IOException: 目标地址不允许访问(...): 127.0.0.1.nip.io -> 127.0.0.1
```
Also blocked for `/parser` and `/json/ce/127.0.0.1.nip.io_s_poc`. Primary advisory path is fixed.

### Residual after `aeb4394` (incomplete remediation)
| Residual | Complexity | Evidence |
|----------|------------|----------|
| Public host `302` → private/metadata | **AC:L** | Vert.x `DEFAULT_FOLLOW_REDIRECTS=true`; CeTool used `clientSession` (follows GET redirects). Local harness: follow-redirects GET to `302 Location: http://127.0.0.1:18080/...` returned `INTERNAL-SSRF-PROOF`. |
| DNS rebinding TOCTOU | **AC:H** | `assertPublicHost` resolves once; Vert.x/Netty resolve again at connect; no IP pin. |
| Upstream body echo in 500 JSON | enables semi-blind SSRF | `PanBase.asJson()` → `fail(..., bodyPreview)` up to 4096 chars. |

**Verdict for advisory maintainers:** do not close as fully fixed on `aeb4394` alone; primary path is remediated, but redirect bypass remained low-complexity.

## This PR changes
1. **CeTool / Ce4Tool**: use `clientNoRedirects` for attacker-controlled host requests (blocks AC:L redirect bypass).
2. **PanBase.asJson()**: log body preview server-side only; do not return it to clients.
3. **AssertPublicHostTest**: regression for advisory host classes.

## Remaining residual
DNS rebinding / connect-time validation is still open (higher complexity). Optional follow-up: pin resolved IPs or custom Vert.x `AddressResolver`.

## Test plan
- [x] Reproduced advisory PoC on `v0.4.1` → marker leaked
- [x] Confirmed PoC blocked on fixed build / this branch
- [x] Vert.x redirect harness: default follow leaks marker; `followRedirects=false` does not
- [x] `AssertPublicHostTest` (2 tests) passed via JUnitCore

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d186d08-e430-4d87-bdbb-f2965eaf2b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d186d08-e430-4d87-bdbb-f2965eaf2b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

